### PR TITLE
Add route inspectors for rewrite cases

### DIFF
--- a/src/app/chat/[[...path]]/page.tsx
+++ b/src/app/chat/[[...path]]/page.tsx
@@ -1,0 +1,35 @@
+import VariableDisplay from "@/components/VariableDisplay";
+import SegmentsList from "@/components/SegmentsList";
+import type { PageSearchParams } from "@/types/next";
+import { buildCatchAllVariables } from "@/utils/rewriteHelpers";
+
+type ChatPageProps = {
+  params: {
+    path?: string[];
+  };
+  searchParams: PageSearchParams;
+};
+
+export default function ChatRewritePage({ params, searchParams }: ChatPageProps) {
+  const segments = params.path ?? [];
+  const variables = buildCatchAllVariables(segments, "path");
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Chat rewrite handler</h1>
+        <p className="text-gray-600">Source pattern: /chat/:path*</p>
+      </div>
+
+      <VariableDisplay variables={variables} searchParams={searchParams} />
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Captured segments</h2>
+        <SegmentsList
+          segments={segments}
+          emptyLabel="Visit a URL like /chat/room/general to see captured segments."
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/demo/page.tsx
+++ b/src/app/demo/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export default function DemoPage() {
   return (
     <div className="p-8">
@@ -8,77 +10,192 @@ export default function DemoPage() {
         <section>
           <h2 className="text-2xl font-semibold mb-4">Basic Category Routes</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li><a href="/nha-dat" className="text-blue-600 hover:underline">/nha-dat</a> → /vv/nha-dat</li>
-            <li><a href="/oto" className="text-blue-600 hover:underline">/oto</a> → /vv/oto</li>
-            <li><a href="/thoi-trang" className="text-blue-600 hover:underline">/thoi-trang</a> → /vv/thoi-trang</li>
+            <li>
+              <Link href="/nha-dat" className="text-blue-600 hover:underline">
+                /nha-dat
+              </Link>{" "}
+              → /vv/nha-dat
+            </li>
+            <li>
+              <Link href="/oto" className="text-blue-600 hover:underline">
+                /oto
+              </Link>{" "}
+              → /vv/oto
+            </li>
+            <li>
+              <Link href="/thoi-trang" className="text-blue-600 hover:underline">
+                /thoi-trang
+              </Link>{" "}
+              → /vv/thoi-trang
+            </li>
           </ul>
         </section>
 
         <section>
           <h2 className="text-2xl font-semibold mb-4">Province Routes</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li><a href="/tinh-Hanoi" className="text-blue-600 hover:underline">/tinh-Hanoi</a> → /vv/tinh/Hanoi</li>
-            <li><a href="/tp-HCM" className="text-blue-600 hover:underline">/tp-HCM</a> → /vv/tp/HCM</li>
-            <li><a href="/thanh-pho-DaNang" className="text-blue-600 hover:underline">/thanh-pho-DaNang</a> → /vv/thanh-pho/DaNang</li>
+            <li>
+              <Link href="/tinh-Hanoi" className="text-blue-600 hover:underline">
+                /tinh-Hanoi
+              </Link>{" "}
+              → /vv/tinh/Hanoi
+            </li>
+            <li>
+              <Link href="/tp-HCM" className="text-blue-600 hover:underline">
+                /tp-HCM
+              </Link>{" "}
+              → /vv/tp/HCM
+            </li>
+            <li>
+              <Link href="/thanh-pho-DaNang" className="text-blue-600 hover:underline">
+                /thanh-pho-DaNang
+              </Link>{" "}
+              → /vv/thanh-pho/DaNang
+            </li>
           </ul>
         </section>
 
         <section>
           <h2 className="text-2xl font-semibold mb-4">District Routes</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li><a href="/quan-BaDinh" className="text-blue-600 hover:underline">/quan-BaDinh</a> → /vv/quan/BaDinh</li>
-            <li><a href="/huyen-HoaiDuc" className="text-blue-600 hover:underline">/huyen-HoaiDuc</a> → /vv/huyen/HoaiDuc</li>
-            <li><a href="/thi-xa-SonTay" className="text-blue-600 hover:underline">/thi-xa-SonTay</a> → /vv/thi-xa/SonTay</li>
+            <li>
+              <Link href="/quan-BaDinh" className="text-blue-600 hover:underline">
+                /quan-BaDinh
+              </Link>{" "}
+              → /vv/quan/BaDinh
+            </li>
+            <li>
+              <Link href="/huyen-HoaiDuc" className="text-blue-600 hover:underline">
+                /huyen-HoaiDuc
+              </Link>{" "}
+              → /vv/huyen/HoaiDuc
+            </li>
+            <li>
+              <Link href="/thi-xa-SonTay" className="text-blue-600 hover:underline">
+                /thi-xa-SonTay
+              </Link>{" "}
+              → /vv/thi-xa/SonTay
+            </li>
           </ul>
         </section>
 
         <section>
           <h2 className="text-2xl font-semibold mb-4">Category + Province Routes</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li><a href="/nha-dat-tinh-Hanoi" className="text-blue-600 hover:underline">/nha-dat-tinh-Hanoi</a> → /vv/nha-dat/tinh/Hanoi</li>
-            <li><a href="/oto-tp-HCM" className="text-blue-600 hover:underline">/oto-tp-HCM</a> → /vv/oto/tp/HCM</li>
+            <li>
+              <Link href="/nha-dat-tinh-Hanoi" className="text-blue-600 hover:underline">
+                /nha-dat-tinh-Hanoi
+              </Link>{" "}
+              → /vv/nha-dat/tinh/Hanoi
+            </li>
+            <li>
+              <Link href="/oto-tp-HCM" className="text-blue-600 hover:underline">
+                /oto-tp-HCM
+              </Link>{" "}
+              → /vv/oto/tp/HCM
+            </li>
           </ul>
         </section>
 
         <section>
           <h2 className="text-2xl font-semibold mb-4">Category + District Routes</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li><a href="/nha-dat-quan-BaDinh" className="text-blue-600 hover:underline">/nha-dat-quan-BaDinh</a> → /vv/nha-dat/quan/BaDinh</li>
-            <li><a href="/oto-huyen-HoaiDuc" className="text-blue-600 hover:underline">/oto-huyen-HoaiDuc</a> → /vv/oto/huyen/HoaiDuc</li>
+            <li>
+              <Link href="/nha-dat-quan-BaDinh" className="text-blue-600 hover:underline">
+                /nha-dat-quan-BaDinh
+              </Link>{" "}
+              → /vv/nha-dat/quan/BaDinh
+            </li>
+            <li>
+              <Link href="/oto-huyen-HoaiDuc" className="text-blue-600 hover:underline">
+                /oto-huyen-HoaiDuc
+              </Link>{" "}
+              → /vv/oto/huyen/HoaiDuc
+            </li>
           </ul>
         </section>
 
         <section>
           <h2 className="text-2xl font-semibold mb-4">Complex Location Routes</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li><a href="/nha-dat-quan-BaDinh-tinh-Hanoi" className="text-blue-600 hover:underline">/nha-dat-quan-BaDinh-tinh-Hanoi</a> → /vv/nha-dat/quan/BaDinh/tinh/Hanoi</li>
-            <li><a href="/oto-huyen-HoaiDuc-tinh-Hanoi" className="text-blue-600 hover:underline">/oto-huyen-HoaiDuc-tinh-Hanoi</a> → /vv/oto/huyen/HoaiDuc/tinh/Hanoi</li>
+            <li>
+              <Link href="/nha-dat-quan-BaDinh-tinh-Hanoi" className="text-blue-600 hover:underline">
+                /nha-dat-quan-BaDinh-tinh-Hanoi
+              </Link>{" "}
+              → /vv/nha-dat/quan/BaDinh/tinh/Hanoi
+            </li>
+            <li>
+              <Link href="/oto-huyen-HoaiDuc-tinh-Hanoi" className="text-blue-600 hover:underline">
+                /oto-huyen-HoaiDuc-tinh-Hanoi
+              </Link>{" "}
+              → /vv/oto/huyen/HoaiDuc/tinh/Hanoi
+            </li>
           </ul>
         </section>
 
         <section>
           <h2 className="text-2xl font-semibold mb-4">Transportation Routes</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li><a href="/van-chuyen" className="text-blue-600 hover:underline">/van-chuyen</a> → /vv/van-chuyen</li>
-            <li><a href="/van-chuyen-tu-Hanoi" className="text-blue-600 hover:underline">/van-chuyen-tu-Hanoi</a> → /vv/van-chuyen/tu/Hanoi</li>
-            <li><a href="/van-chuyen-di-HCM" className="text-blue-600 hover:underline">/van-chuyen-di-HCM</a> → /vv/van-chuyen/di/HCM</li>
-            <li><a href="/van-chuyen-tu-Hanoi-di-HCM" className="text-blue-600 hover:underline">/van-chuyen-tu-Hanoi-di-HCM</a> → /vv/van-chuyen/tu/Hanoi/di/HCM</li>
+            <li>
+              <Link href="/van-chuyen" className="text-blue-600 hover:underline">
+                /van-chuyen
+              </Link>{" "}
+              → /vv/van-chuyen
+            </li>
+            <li>
+              <Link href="/van-chuyen-tu-Hanoi" className="text-blue-600 hover:underline">
+                /van-chuyen-tu-Hanoi
+              </Link>{" "}
+              → /vv/van-chuyen/tu/Hanoi
+            </li>
+            <li>
+              <Link href="/van-chuyen-di-HCM" className="text-blue-600 hover:underline">
+                /van-chuyen-di-HCM
+              </Link>{" "}
+              → /vv/van-chuyen/di/HCM
+            </li>
+            <li>
+              <Link href="/van-chuyen-tu-Hanoi-di-HCM" className="text-blue-600 hover:underline">
+                /van-chuyen-tu-Hanoi-di-HCM
+              </Link>{" "}
+              → /vv/van-chuyen/tu/Hanoi/di/HCM
+            </li>
           </ul>
         </section>
 
         <section>
           <h2 className="text-2xl font-semibold mb-4">Sitemap Routes</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li><a href="/sitemap/tinh-thanh/hanoi.xml" className="text-blue-600 hover:underline">/sitemap/tinh-thanh/hanoi.xml</a> → /sitemap/tinh-thanh/hanoi</li>
-            <li><a href="/sitemap/quan-huyen/badinh.xml" className="text-blue-600 hover:underline">/sitemap/quan-huyen/badinh.xml</a> → /sitemap/quan-huyen/badinh</li>
+            <li>
+              <Link href="/sitemap/tinh-thanh/hanoi.xml" className="text-blue-600 hover:underline">
+                /sitemap/tinh-thanh/hanoi.xml
+              </Link>{" "}
+              → /sitemap/tinh-thanh/hanoi
+            </li>
+            <li>
+              <Link href="/sitemap/quan-huyen/badinh.xml" className="text-blue-600 hover:underline">
+                /sitemap/quan-huyen/badinh.xml
+              </Link>{" "}
+              → /sitemap/quan-huyen/badinh
+            </li>
           </ul>
         </section>
 
         <section>
           <h2 className="text-2xl font-semibold mb-4">Other Routes</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li><a href="/rss" className="text-blue-600 hover:underline">/rss</a> → /api/rss</li>
-            <li><a href="/thuong-mai/slug1/slug2" className="text-blue-600 hover:underline">/slug1/slug2</a> → /thuong-mai/slug1/slug2</li>
+            <li>
+              <Link href="/rss" className="text-blue-600 hover:underline">
+                /rss
+              </Link>{" "}
+              → /api/rss
+            </li>
+            <li>
+              <Link href="/thuong-mai/slug1/slug2" className="text-blue-600 hover:underline">
+                /slug1/slug2
+              </Link>{" "}
+              → /thuong-mai/slug1/slug2
+            </li>
           </ul>
         </section>
       </div>

--- a/src/app/rating/[[...path]]/page.tsx
+++ b/src/app/rating/[[...path]]/page.tsx
@@ -1,0 +1,35 @@
+import VariableDisplay from "@/components/VariableDisplay";
+import SegmentsList from "@/components/SegmentsList";
+import type { PageSearchParams } from "@/types/next";
+import { buildCatchAllVariables } from "@/utils/rewriteHelpers";
+
+type RatingPageProps = {
+  params: {
+    path?: string[];
+  };
+  searchParams: PageSearchParams;
+};
+
+export default function RatingRewritePage({ params, searchParams }: RatingPageProps) {
+  const segments = params.path ?? [];
+  const variables = buildCatchAllVariables(segments, "path");
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Rating rewrite handler</h1>
+        <p className="text-gray-600">Source pattern: /rating/:path*</p>
+      </div>
+
+      <VariableDisplay variables={variables} searchParams={searchParams} />
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Captured segments</h2>
+        <SegmentsList
+          segments={segments}
+          emptyLabel="Visit a URL like /rating/san-pham/123 to see captured segments."
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/thuong-mai/[slug]/[slug1]/page.tsx
+++ b/src/app/thuong-mai/[slug]/[slug1]/page.tsx
@@ -1,0 +1,36 @@
+import VariableDisplay from "@/components/VariableDisplay";
+import SegmentsList from "@/components/SegmentsList";
+import type { PageSearchParams } from "@/types/next";
+
+type ThuongMaiPageProps = {
+  params: {
+    slug: string;
+    slug1: string;
+  };
+  searchParams: PageSearchParams;
+};
+
+export default function ThuongMaiRewritePage({ params, searchParams }: ThuongMaiPageProps) {
+  const variables = {
+    slug: params.slug,
+    slug1: params.slug1,
+  };
+
+  const segments = [params.slug, params.slug1];
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Thương mại rewrite handler</h1>
+        <p className="text-gray-600">Source pattern: /:slug/:slug1</p>
+      </div>
+
+      <VariableDisplay variables={variables} searchParams={searchParams} />
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Captured segments</h2>
+        <SegmentsList segments={segments} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/tin-he-thong/[[...path]]/page.tsx
+++ b/src/app/tin-he-thong/[[...path]]/page.tsx
@@ -1,0 +1,35 @@
+import VariableDisplay from "@/components/VariableDisplay";
+import SegmentsList from "@/components/SegmentsList";
+import type { PageSearchParams } from "@/types/next";
+import { buildCatchAllVariables } from "@/utils/rewriteHelpers";
+
+type TinHeThongPageProps = {
+  params: {
+    path?: string[];
+  };
+  searchParams: PageSearchParams;
+};
+
+export default function TinHeThongRewritePage({ params, searchParams }: TinHeThongPageProps) {
+  const segments = params.path ?? [];
+  const variables = buildCatchAllVariables(segments, "path");
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Tin hệ thống rewrite handler</h1>
+        <p className="text-gray-600">Source pattern: /tin-he-thong/:path*</p>
+      </div>
+
+      <VariableDisplay variables={variables} searchParams={searchParams} />
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Captured segments</h2>
+        <SegmentsList
+          segments={segments}
+          emptyLabel="Visit a URL like /tin-he-thong/thong-bao/mo-ta to see captured segments."
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/tin-tuc/[[...path]]/page.tsx
+++ b/src/app/tin-tuc/[[...path]]/page.tsx
@@ -1,0 +1,35 @@
+import VariableDisplay from "@/components/VariableDisplay";
+import SegmentsList from "@/components/SegmentsList";
+import type { PageSearchParams } from "@/types/next";
+import { buildCatchAllVariables } from "@/utils/rewriteHelpers";
+
+type TinTucPageProps = {
+  params: {
+    path?: string[];
+  };
+  searchParams: PageSearchParams;
+};
+
+export default function TinTucRewritePage({ params, searchParams }: TinTucPageProps) {
+  const segments = params.path ?? [];
+  const variables = buildCatchAllVariables(segments, "path");
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Tin tức rewrite handler</h1>
+        <p className="text-gray-600">Source pattern: /tin-tuc/:path*</p>
+      </div>
+
+      <VariableDisplay variables={variables} searchParams={searchParams} />
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Captured segments</h2>
+        <SegmentsList
+          segments={segments}
+          emptyLabel="Visit a URL like /tin-tuc/cong-nghe/ai to see captured segments."
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/user/[[...path]]/page.tsx
+++ b/src/app/user/[[...path]]/page.tsx
@@ -1,0 +1,35 @@
+import VariableDisplay from "@/components/VariableDisplay";
+import SegmentsList from "@/components/SegmentsList";
+import type { PageSearchParams } from "@/types/next";
+import { buildCatchAllVariables } from "@/utils/rewriteHelpers";
+
+type UserPageProps = {
+  params: {
+    path?: string[];
+  };
+  searchParams: PageSearchParams;
+};
+
+export default function UserRewritePage({ params, searchParams }: UserPageProps) {
+  const segments = params.path ?? [];
+  const variables = buildCatchAllVariables(segments, "path");
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">User rewrite handler</h1>
+        <p className="text-gray-600">Source pattern: /user/:path*</p>
+      </div>
+
+      <VariableDisplay variables={variables} searchParams={searchParams} />
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Captured segments</h2>
+        <SegmentsList
+          segments={segments}
+          emptyLabel="Visit a URL like /user/profile/edit to see captured segments."
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/van-chuyen/[slug]/page.tsx
+++ b/src/app/van-chuyen/[slug]/page.tsx
@@ -1,0 +1,34 @@
+import VariableDisplay from "@/components/VariableDisplay";
+import SegmentsList from "@/components/SegmentsList";
+import type { PageSearchParams } from "@/types/next";
+
+type VanChuyenSlugPageProps = {
+  params: {
+    slug: string;
+  };
+  searchParams: PageSearchParams;
+};
+
+export default function VanChuyenSlugPage({ params, searchParams }: VanChuyenSlugPageProps) {
+  const variables = {
+    slug: params.slug,
+  };
+
+  const segments = [params.slug];
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">Vận chuyển rewrite handler</h1>
+        <p className="text-gray-600">Source pattern: /van-chuyen/:slug</p>
+      </div>
+
+      <VariableDisplay variables={variables} searchParams={searchParams} />
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Captured segments</h2>
+        <SegmentsList segments={segments} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/vv/[[...segments]]/page.tsx
+++ b/src/app/vv/[[...segments]]/page.tsx
@@ -1,0 +1,240 @@
+import VariableDisplay from "@/components/VariableDisplay";
+import SegmentsList from "@/components/SegmentsList";
+import type { PageSearchParams } from "@/types/next";
+
+type VvPageProps = {
+  params: {
+    segments?: string[];
+  };
+  searchParams: PageSearchParams;
+};
+
+type CaseResult = {
+  title: string;
+  description: string;
+  sourcePattern: string;
+  variables: Record<string, string> | null;
+};
+
+const districtPrefixes = new Set(["quan", "huyen", "thi-xa", "thanh-pho", "tp"]);
+const provincePrefixes = new Set(["tp", "tinh", "thanh-pho"]);
+
+const hasDistrictPrefix = (value: string) => districtPrefixes.has(value);
+const hasProvincePrefix = (value: string) => provincePrefixes.has(value);
+
+const mapSegments = (segments: string[], startIndex = 0) =>
+  segments.reduce<Record<string, string>>((acc, value, index) => {
+    acc[`segment${startIndex + index}`] = value;
+    return acc;
+  }, {});
+
+const parseTransportationSegments = (segments: string[]): CaseResult => {
+  if (segments.length === 1) {
+    return {
+      title: "Transportation landing rewrite",
+      description: "Matches the /van-chuyen source URL with no extra parameters.",
+      sourcePattern: "/van-chuyen",
+      variables: null,
+    };
+  }
+
+  if (segments.length === 3) {
+    const [, province1, province1Value] = segments;
+
+    return {
+      title: "Transportation single-endpoint rewrite",
+      description: 'Handles sources such as "/van-chuyen-tu-Hanoi" or "/van-chuyen-di-HCM".',
+      sourcePattern: "/van-chuyen-:province1(tu|di)-:province1Value",
+      variables: {
+        province1,
+        province1Value,
+      },
+    };
+  }
+
+  if (segments.length === 5) {
+    const [, province1, province1Value, province2, province2Value] = segments;
+
+    return {
+      title: "Transportation full-route rewrite",
+      description: 'Handles sources such as "/van-chuyen-tu-Hanoi-di-HCM".',
+      sourcePattern: "/van-chuyen-:province1(tu)-:province1Value-:province2(di)-:province2Value",
+      variables: {
+        province1,
+        province1Value,
+        province2,
+        province2Value,
+      },
+    };
+  }
+
+  return {
+    title: "Transportation rewrite (unrecognized pattern)",
+    description:
+      "The provided /vv/van-chuyen segments do not match any rewrite declared in next.config.ts.",
+    sourcePattern:
+      "/van-chuyen, /van-chuyen-:province1(tu|di)-:province1Value, or /van-chuyen-:province1(tu)-:province1Value-:province2(di)-:province2Value",
+    variables: mapSegments(segments.slice(1), 1),
+  };
+};
+
+const parseVvSegments = (segments: string[]): CaseResult => {
+  if (segments.length === 0) {
+    return {
+      title: "Direct /vv access",
+      description: "No rewrite matched because there are no segments after /vv.",
+      sourcePattern: "Direct visit to /vv",
+      variables: null,
+    };
+  }
+
+  if (segments[0] === "van-chuyen") {
+    return parseTransportationSegments(segments);
+  }
+
+  if (segments.length === 1) {
+    const [category] = segments;
+
+    return {
+      title: "Category rewrite",
+      description: 'Matches source paths like "/nha-dat" or "/oto".',
+      sourcePattern: "/:category",
+      variables: { category },
+    };
+  }
+
+  if (segments.length === 2) {
+    const [prefix, value] = segments;
+
+    if (hasProvincePrefix(prefix)) {
+      return {
+        title: "Province rewrite",
+        description: 'Matches source paths like "/tinh-Hanoi" or "/tp-HCM".',
+        sourcePattern: "/:province(tp|tinh|thanh-pho)-:provinceValue",
+        variables: {
+          province: prefix,
+          provinceValue: value,
+        },
+      };
+    }
+
+    if (hasDistrictPrefix(prefix)) {
+      return {
+        title: "District rewrite",
+        description: 'Matches source paths like "/quan-BaDinh" or "/huyen-HoaiDuc".',
+        sourcePattern: "/:district(quan|huyen|thi-xa|thanh-pho|tp)-:districtValue",
+        variables: {
+          district: prefix,
+          districtValue: value,
+        },
+      };
+    }
+  }
+
+  if (segments.length === 3) {
+    const [category, qualifier, qualifierValue] = segments;
+
+    if (hasProvincePrefix(qualifier)) {
+      return {
+        title: "Category + province rewrite",
+        description: 'Matches source paths like "/nha-dat-tinh-Hanoi" or "/oto-tp-HCM".',
+        sourcePattern: "/:category-:province(tp|tinh|thanh-pho)-:provinceValue",
+        variables: {
+          category,
+          province: qualifier,
+          provinceValue: qualifierValue,
+        },
+      };
+    }
+
+    if (hasDistrictPrefix(qualifier)) {
+      return {
+        title: "Category + district rewrite",
+        description: 'Matches source paths like "/nha-dat-quan-BaDinh".',
+        sourcePattern: "/:category-:district(quan|huyen|thi-xa|thanh-pho|tp)-:districtValue",
+        variables: {
+          category,
+          district: qualifier,
+          districtValue: qualifierValue,
+        },
+      };
+    }
+  }
+
+  if (segments.length === 4) {
+    const [district, districtValue, province, provinceValue] = segments;
+
+    if (hasDistrictPrefix(district) && hasProvincePrefix(province)) {
+      return {
+        title: "District + province rewrite",
+        description: 'Matches source paths like "/quan-BaDinh-tinh-Hanoi".',
+        sourcePattern:
+          "/:district(quan|huyen|thi-xa|thanh-pho|tp)-:districtValue-:province(tp|tinh|thanh-pho)-:provinceValue",
+        variables: {
+          district,
+          districtValue,
+          province,
+          provinceValue,
+        },
+      };
+    }
+  }
+
+  if (segments.length === 5) {
+    const [category, district, districtValue, province, provinceValue] = segments;
+
+    if (hasDistrictPrefix(district) && hasProvincePrefix(province)) {
+      return {
+        title: "Category + district + province rewrite",
+        description: 'Matches source paths like "/nha-dat-quan-BaDinh-tinh-Hanoi".',
+        sourcePattern:
+          "/:category-:district(quan|huyen|thi-xa|thanh-pho|tp)-:districtValue-:province(tp|tinh|thanh-pho)-:provinceValue",
+        variables: {
+          category,
+          district,
+          districtValue,
+          province,
+          provinceValue,
+        },
+      };
+    }
+  }
+
+  return {
+    title: "Unrecognized /vv rewrite",
+    description: "The segments do not correspond to any rewrite defined in next.config.ts.",
+    sourcePattern: "No matching rewrite pattern",
+    variables: mapSegments(segments),
+  };
+};
+
+export default function VvRewritePage({ params, searchParams }: VvPageProps) {
+  const segments = params.segments ?? [];
+  const caseResult = parseVvSegments(segments);
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold">/vv Rewrite Inspector</h1>
+        <p className="text-gray-600">
+          Visualises the values captured by the rewrite patterns declared in next.config.ts for /vv routes.
+        </p>
+      </div>
+
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold">{caseResult.title}</h2>
+        <p className="text-gray-600">{caseResult.description}</p>
+        <p className="font-mono text-sm bg-gray-100 border border-gray-200 rounded px-3 py-2 inline-block">
+          {caseResult.sourcePattern}
+        </p>
+      </div>
+
+      <VariableDisplay variables={caseResult.variables} searchParams={searchParams} />
+
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Segments after /vv</h2>
+        <SegmentsList segments={segments} emptyLabel="No segments were provided after /vv." />
+      </div>
+    </div>
+  );
+}

--- a/src/components/SegmentsList.tsx
+++ b/src/components/SegmentsList.tsx
@@ -1,0 +1,25 @@
+export type SegmentsListProps = {
+  segments: string[];
+  emptyLabel?: string;
+};
+
+export default function SegmentsList({
+  segments,
+  emptyLabel = "No dynamic segments were provided.",
+}: SegmentsListProps) {
+  return (
+    <div className="bg-slate-50 border border-slate-200 rounded-lg p-4">
+      {segments.length > 0 ? (
+        <ul className="list-decimal pl-5 space-y-1">
+          {segments.map((segment, index) => (
+            <li key={`${segment}-${index}`} className="text-sm font-mono">
+              <span className="text-slate-600">[{index}]</span> {segment}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-slate-600">{emptyLabel}</p>
+      )}
+    </div>
+  );
+}

--- a/src/types/next.ts
+++ b/src/types/next.ts
@@ -1,0 +1,3 @@
+export type PageSearchParams =
+  | Promise<Record<string, string | string[] | undefined>>
+  | Record<string, string | string[] | undefined>;

--- a/src/utils/rewriteHelpers.ts
+++ b/src/utils/rewriteHelpers.ts
@@ -1,0 +1,16 @@
+export const buildCatchAllVariables = (segments: string[], paramName: string) => {
+  if (segments.length === 0) {
+    return null;
+  }
+
+  const joinedValue = segments.join("/");
+
+  return segments.reduce<Record<string, string>>((acc, value, index) => {
+    if (index === 0) {
+      acc[paramName] = joinedValue;
+    }
+
+    acc[`${paramName}[${index}]`] = value;
+    return acc;
+  }, {});
+};


### PR DESCRIPTION
## Summary
- add dynamic pages that surface captured parameters for the chat, user, tin tức, rating, tin hệ thống, vận chuyển and thương mại rewrites
- implement a /vv optional catch-all inspector that parses rewrite-specific segment layouts and reports the extracted values
- introduce reusable helpers for displaying segments and building catch-all variables while updating the demo links to use next/link

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d175707b548323acf3df3d926de1c9